### PR TITLE
Update jump

### DIFF
--- a/The Dark Tower/Assets/Animations/Player/Jump_Fall.anim
+++ b/The Dark Tower/Assets/Animations/Player/Jump_Fall.anim
@@ -55,7 +55,7 @@ AnimationClip:
     m_StopTime: 0.375
     m_OrientationOffsetY: 0
     m_Level: 0
-    m_CycleOffset: 1
+    m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
     m_LoopTime: 0
     m_LoopBlend: 0

--- a/The Dark Tower/Assets/Animations/Player/Player.controller
+++ b/The Dark Tower/Assets/Animations/Player/Player.controller
@@ -184,6 +184,34 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-5698101247118602190
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Jumping
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: Falling
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -585727330090033743}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-5575409818372409474
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1036,6 +1064,7 @@ AnimatorStateMachine:
   m_AnyStateTransitions:
   - {fileID: 7373106953043964028}
   - {fileID: 3884840496346779935}
+  - {fileID: -5698101247118602190}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []

--- a/The Dark Tower/Assets/Scenes/SampleScene.unity
+++ b/The Dark Tower/Assets/Scenes/SampleScene.unity
@@ -2467,7 +2467,7 @@ CapsuleCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: -0.375}
-  m_Size: {x: 1.0625, y: 1.0625}
+  m_Size: {x: 1, y: 1}
   m_Direction: 0
 --- !u!50 &2034431293
 Rigidbody2D:
@@ -2485,8 +2485,8 @@ Rigidbody2D:
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
+  m_Material: {fileID: 6200000, guid: 933adfe70c9a3854b9a106d4f5a921bc, type: 2}
+  m_Interpolate: 1
   m_SleepingMode: 1
   m_CollisionDetection: 1
   m_Constraints: 4
@@ -2600,7 +2600,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1.0625, y: 1.0297536}
+  m_Size: {x: 0.9, y: 1}
   m_EdgeRadius: 0
 --- !u!114 &2034431298
 MonoBehaviour:
@@ -2618,6 +2618,7 @@ MonoBehaviour:
   runspeed: 40
   animator: {fileID: 2034431296}
   playerRigidBody2D: {fileID: 0}
+  canJump: 0
 --- !u!114 &2034431299
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/The Dark Tower/Assets/Scripts/PlayerMovement.cs
+++ b/The Dark Tower/Assets/Scripts/PlayerMovement.cs
@@ -11,6 +11,7 @@ public class PlayerMovement : MonoBehaviour
     bool crouch=false;
     public Animator animator;
     public Rigidbody2D playerRigidBody2D;
+    public float canJump = 0f;
 
 
 
@@ -29,11 +30,13 @@ public class PlayerMovement : MonoBehaviour
         animator.SetFloat("Speed", Mathf.Abs(horizontalmove));
 
             
-        if (Input.GetButtonDown("Jump"))
+        if (Input.GetButtonDown("Jump") && Time.time > canJump)
         {
             jump = true;
             animator.SetBool("Jumping", true);
+            
         }
+        
 
         if (Input.GetButtonDown("Crouch"))
         {
@@ -47,8 +50,11 @@ public class PlayerMovement : MonoBehaviour
 
     public void OnLanding()
     {
-        animator.SetBool("Jumping",false);
+        canJump = Time.time + 0.2f;
+        animator.SetBool("Jumping", false);
+        
     }
+    
 
     public void OnCrouching(bool isCrouching)
     {


### PR DESCRIPTION
-Added Jump Delay
-Fixed Any State -> Falling issue (Does not send the extra frame anymore)
-Decreased size of colliders by a small amount to avoid getting stuck in walls.
(happened cuz box collider and capsule collider had a lil space in between, which can get stuck to walls and put you in permeant jump)

Requesting
- Jump delay review (For polishing)
- Should we add a jump cut (jump time depends on how long jump is pressed for. like hollow knight.)
